### PR TITLE
Githubという不特定多数の人に見られる場所にNyaXのリンクが貼ってあった問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,11 +64,11 @@
             <div id="recommendations-widget-container"></div>
             <!-- NyaXルール(重要) -->
             <div class="links">
-                <a class="link" href="https://nyax.onrender.com/rule">NyaXルール</a>
-                <a class="link" href="https://nyax.onrender.com/ranking">各種ランキング</a>
-                <a class="link" href="https://nyax.onrender.com/stat">統計</a>
+                <a class="link" href="/rule">NyaXルール</a>
+                <a class="link" href="/ranking">各種ランキング</a>
+                <a class="link" href="/stat">統計</a>
                 <a class="link" href="https://docs.google.com/forms/d/e/1FAIpQLSdTJ83q1ZGlDqJ8u30tlcNCwhaoCsUdmMAsq0-8pVL5v5V27A/viewform">申請フォーム</a>
-                <a class="link" href="https://nyax.onrender.com/emoji">Emoji一覧</a>
+                <a class="link" href="/emoji">Emoji一覧</a>
                 <a class="link-end" href="https://discord.gg/bYkheTzU5n">Discord鯖</a>
             </div>
         </aside>


### PR DESCRIPTION
NyaXルール「NyaXのURLに関するルール」より
> 1. ScratchやXなどの**不特定多数が閲覧できる場所**にNyaXのURLを貼ることを禁止します

Githubはこの**不特定多数が閲覧できる場所**となると考えたためプルリクを送ります。

場所としては、NyaXルールなどが表示される右側の場所のリンクで、絶対パスを相対パスに置き換えました。

ただ、コミット履歴には残ってしまうという難点があり、難しいところです。