### PR TITLE
リンクが折り返されるようにする

### DIFF
--- a/style.css
+++ b/style.css
@@ -560,6 +560,10 @@ input, textarea {
     cursor: pointer;
 }
 
+.user-me {
+    line-break: anywhere;
+}
+
 .post-content a,
 .user-me a,
 .notification-item-content a {


### PR DESCRIPTION
NyaXではポストや自己紹介のリンクが長いとはみ出すバグ(?)がありました。
そのため、CSSで`line-break`ルールを適用して、はみ出さないようにしました。