### PR TITLE
SVGアイコン「home」の修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
      // --- 2. アイコンSVG定義 ---
     const ICONS = {
-        home: `<svg viewBox="0 0 24 24"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><rect x="9" y="12" width="6" height="10"></rect></svg>`,
+        home: `<svg viewBox="0 0 24 24"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><rect x="9" y="12" width="6" height="11"></rect></svg>`,
         dm: `<svg viewBox="0 0 24 24"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path><polyline points="22,6 12,13 2,6"></polyline></svg>`,
         send: `<svg viewBox="0 0 24 24"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg>`,
         explore: `<svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`,


### PR DESCRIPTION
赤丸で囲んだところの線が見えるのが気になったので修正
<img width="133" height="37" alt="Group 205" src="https://github.com/user-attachments/assets/0effd4c7-be48-4754-bff2-8bc355fa8772" />
修正後はこのように表示されます
<img width="133" height="34" alt="スクリーンショット 2025-10-20 210324" src="https://github.com/user-attachments/assets/21522af5-7785-429b-a385-7f178989ad73" />