### PR TITLE
画像を拡大表示させた時、画像が中央に来ないバグ(？)を改善

### DIFF
--- a/style.css
+++ b/style.css
@@ -1055,7 +1055,6 @@ input, textarea {
     justify-content: center;
     align-items: flex-start;
     z-index: 1001;
-    padding-top: 5vh;
 }
 
 .modal-content {


### PR DESCRIPTION
これが
<img width="1912" height="954" alt="修正前" src="https://github.com/user-attachments/assets/9af35e0b-09aa-42af-9f27-daaee7da84e3" />
こうなります
<img width="1912" height="954" alt="修正後" src="https://github.com/user-attachments/assets/1ab0ff71-ba7a-406f-af4c-b8b13b3f9696" />
この`padding-top: 5vh;`は意図して入れたものなのかどうかは分からなかったのですが、一応PRを送信させていただきました
意図して入れたものだったら申し訳ないです