### PR TITLE
ハッシュタグに絵文字コードを入れるとバグるのを修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -242,7 +242,7 @@ window.addEventListener('DOMContentLoaded', () => {
             });
 
             // 3. ハッシュタグとメンションを置換
-            const hashtagRegex = /#(\S+)/g;
+            const hashtagRegex = /#([a-zA-Z0-9\u3040-\u30FF\u4E00-\u9FFF_!?.-]+)/g;
             processed = processed.replace(hashtagRegex, (match, tagName) => {
                 return `<a href="#search/${encodeURIComponent(tagName)}" onclick="event.stopPropagation()">#${tagName}</a>`;
             });


### PR DESCRIPTION
ハッシュタグに絵文字コードを入れるとバグる報告が上がってたので、
ハッシュタグの正規表現で`<img`のようなものがヒットしないようにしました。

多分過去のコードとのハッシュタグの互換性が異なると思いますが、
私が確認した範囲では大体正常に認識されていました。