### PR TITLE
Scratchアカウント名が公開されている時にScratchへのリンクを追加する

### DIFF
--- a/main.js
+++ b/main.js
@@ -2202,7 +2202,7 @@ window.addEventListener('DOMContentLoaded', () => {
                         ${escapeHTML(user.name)}
                         ${user.admin ? `<img src="icons/admin.png" class="admin-badge" title="NyaXTeam">` : ((await contributors).includes(user.id) ? `<img src="icons/contributor.png" class="contributor-badge" title="コントリビューター">` : (user.verify ? `<img src="icons/verify.png" class="verify-badge" title="認証済み">` : ''))}
                     </h2>
-                    <div class="user-id">#${user.id} ${user.settings.show_scid ? `(@${user.scid})` : ''}</div>
+                    <div class="user-id">#${user.id} ${user.settings.show_scid ? `(<a href="https://scratch.mit.edu/users/${user.scid}" class="scidlink">@${user.scid}</a>)` : ''}</div>
                     <p class="user-me">${userMeHtml}</p>
                     <div class="user-stats">
                         <a href="#profile/${user.id}/following"><strong>${user.follow?.length || 0}</strong> フォロー中</a>

--- a/style.css
+++ b/style.css
@@ -1248,6 +1248,16 @@ input, textarea {
     display: flex;
 }
 
+.scidlink {
+    color: var(--secondary-text-color);
+    border: none;
+    text-decoration: none;
+}
+
+.scidlink:hover {
+    border-bottom: 1px black solid;
+}
+
 .media-grid-container {
     display: grid;
     grid-template-columns: repeat(3, 1fr); /* 3カラム表示 */


### PR DESCRIPTION
https://github.com/TAMAGO55123/nyax-user-linker の機能実装です。
拡張機能としてめんどくさいコードを書くならいっそPR送ってしまえってことです。(正規表現なりなんなり)
hoverを使用し、ホバーした時だけ下線が表示されるような改良を行いました。
ユーザー名をコピペする手間がなくなるのでいいと思っています。
<img width="714" height="177" alt="スクリーンショット 2025-10-28 16 28 46" src="https://github.com/user-attachments/assets/54b47289-a42c-44db-bd76-f8195ecbd102" />